### PR TITLE
Faster inference: Implemented EOT for causal sampling stopping

### DIFF
--- a/fam/llm/mixins/causal.py
+++ b/fam/llm/mixins/causal.py
@@ -254,8 +254,7 @@ class CausalInferenceMixin:
 
             # Check if the generated token is the EOT token
             if torch.any(idx_next == eot_id):
-                print("EOT token encountered, stopping generation.")
-                break  # Break the loop if EOT token is generated
+                break
 
             # append sampled index to the running sequence and continue
             idx = torch.cat((idx, idx_next), dim=2)


### PR DESCRIPTION
Through printing each generated token id tensor, I found token `2048` to be the EOT token.

Before, the inference code sampled all tokens despite EOTs being emitted. Therefore, I implemented early stopping in `casual.py`.