### PR TITLE
fix: propagate `precision` correctly to enable non-bf16 inference

### DIFF
--- a/fam/llm/fast_inference_utils.py
+++ b/fam/llm/fast_inference_utils.py
@@ -206,7 +206,7 @@ def generate(
     device, dtype = prompt.device, prompt.dtype
 
     seq = torch.clone(prompt)
-    input_pos = torch.arange(0, T, device=device)
+    input_pos = torch.arange(0, T, device=device, dtype=dtype)
 
     next_token = prefill(model, prompt.view(1, -1).repeat(2, 1), spk_emb, input_pos, **sampling_kwargs)
     seq = torch.cat([seq, next_token.view(1)])
@@ -278,7 +278,7 @@ def _load_model(
             k = k.replace(".mlp.c_proj.", ".feed_forward.w2.")
 
     model.load_state_dict(state_dict, assign=True)
-    model = model.to(device=device, dtype=torch.bfloat16)
+    model = model.to(device=device, dtype=precision)
 
     if quantisation_mode == "int8":
         warnings.warn(
@@ -291,7 +291,7 @@ def _load_model(
         quantized_state_dict = simple_quantizer.create_quantized_state_dict()
         model = simple_quantizer.convert_for_runtime()
         model.load_state_dict(quantized_state_dict, assign=True)
-        model = model.to(device=device, dtype=torch.bfloat16)
+        model = model.to(device=device, dtype=precision)
         # TODO: int8/int4 doesn't decrease VRAM usage substantially... fix that (might be linked to kv-cache)
         torch.cuda.empty_cache()
     elif quantisation_mode == "int4":
@@ -302,7 +302,7 @@ def _load_model(
         quantized_state_dict = simple_quantizer.create_quantized_state_dict()
         model = simple_quantizer.convert_for_runtime(use_cuda=True)
         model.load_state_dict(quantized_state_dict, assign=True)
-        model = model.to(device=device, dtype=torch.bfloat16)
+        model = model.to(device=device, dtype=precision)
         torch.cuda.empty_cache()
     elif quantisation_mode is not None:
         raise Exception(f"Invalid quantisation mode {quantisation_mode}! Must be either 'int4' or 'int8'!")

--- a/fam/llm/fast_model.py
+++ b/fam/llm/fast_model.py
@@ -188,8 +188,8 @@ class Attention(nn.Module):
 
         total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
         # key, query, value projections for all heads, but in a batch
-        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False, dtype=config.dtype)
-        self.wo = nn.Linear(config.dim, config.dim, bias=False, dtype=config.dtype)
+        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False)
+        self.wo = nn.Linear(config.dim, config.dim, bias=False)
         self.kv_cache = None
 
         self.n_head = config.n_head

--- a/fam/llm/fast_model.py
+++ b/fam/llm/fast_model.py
@@ -188,8 +188,8 @@ class Attention(nn.Module):
 
         total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
         # key, query, value projections for all heads, but in a batch
-        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False)
-        self.wo = nn.Linear(config.dim, config.dim, bias=False)
+        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False, dtype=config.dtype)
+        self.wo = nn.Linear(config.dim, config.dim, bias=False, dtype=config.dtype)
         self.kv_cache = None
 
         self.n_head = config.n_head


### PR DESCRIPTION
This PR fixes some incompatibilities that I encountered when instantiating `TSS` from `fam/llm/fast_inference.py` with older and less powerful GPUs (e.g. Google Colab T4 GPU).

`fam/llm/fast_inference_utils.py` was putting the model to the `device` (cuda) with `dtype.bfloat16` instead of using the `precision` parameter that contains the selected dtype (by default `float16` or `bfloat16` depending on the GPU architecture).

The linear layer of the `Attention` class in `fam/llm/fast_model.py` was also missing the dtype definition using the one provided in the config.