### PR TITLE
fixed ANONYMIZED_TELEMETRY not working as intended

### DIFF
--- a/fam/telemetry/posthog.py
+++ b/fam/telemetry/posthog.py
@@ -18,7 +18,7 @@ class PosthogClient(TelemetryClient):
             project_api_key="phc_tk7IUlV7Q7lEa9LNbXxyC1sMWlCqiW6DkHyhJrbWMCS", host="https://eu.posthog.com"
         )
 
-        if not os.getenv("ANONYMIZED_TELEMETRY", True) or "pytest" in sys.modules:
+        if not bool(os.getenv("ANONYMIZED_TELEMETRY", True)) or "pytest" in sys.modules:
             self._posthog.disabled = True
             logger.info("Anonymized telemetry disabled. See fam/telemetry/README.md for more information.")
         else:


### PR DESCRIPTION
python's `getenv` always return a string, and the truth value of a string is wether the string is empty or not.

setting `ANONYMIZED_TELEMETRY="False"` in env result in telemetry being on, which is not the intended behaviour.

This MR fixed this by casting the value to a boolean using bool().

Note: that on current upstream version the telemetry can be disabled with `ANONYMIZED_TELEMETRY=""` which this MR doesn't support.